### PR TITLE
Fix dotnet version out of date

### DIFF
--- a/csharp/csharp.csproj
+++ b/csharp/csharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 


### PR DESCRIPTION
Dotnet v2.2 is hopelessly out of date. Updated to v6.0 (most recent) to make the example functional. fixes issue #112