### PR TITLE
Update to Zeebe 8.0.6

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -2,7 +2,7 @@ module github.com/camunda/camunda-platform-get-started/go
 
 go 1.17
 
-require github.com/camunda/zeebe/clients/go/v8 v8.0.5
+require github.com/camunda/zeebe/clients/go/v8 v8.0.6
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -39,6 +39,8 @@ github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/camunda/zeebe/clients/go/v8 v8.0.5 h1:AVhSgRMFlHc8VgvyenyStxsoWAJzjAcy14wViQUJD9s=
 github.com/camunda/zeebe/clients/go/v8 v8.0.5/go.mod h1:vqeNO1EphExqC15spP56PNXQ6SB8sMjhEfO16bfFRPo=
+github.com/camunda/zeebe/clients/go/v8 v8.0.6 h1:6bIx/wdrjMlXs8+XZ2eJxru4XZwz9lMCgv2H2g8VEFM=
+github.com/camunda/zeebe/clients/go/v8 v8.0.6/go.mod h1:vqeNO1EphExqC15spP56PNXQ6SB8sMjhEfO16bfFRPo=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <zeebe.version>8.0.5</zeebe.version>
+    <zeebe.version>8.0.6</zeebe.version>
     <log4j.version>2.18.0</log4j.version>
     <main.class>io.camunda.getstarted.DeployAndStartInstance</main.class>
   </properties>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -19,7 +19,7 @@
 	<properties>
 		<java.version>11</java.version>
 		<spring-zeebe.version>8.0.7</spring-zeebe.version>
-		<zeebe.version>8.0.5</zeebe.version>
+		<zeebe.version>8.0.6</zeebe.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
- dump Zeebe from 8.0.5 to 8.0.6
- dump Zeebe's go client from 8.0.5 to 8.0.6