### PR TITLE
Zeebe release 8.1.1

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -2,7 +2,7 @@ module github.com/camunda/camunda-platform-get-started/go
 
 go 1.17
 
-require github.com/camunda/zeebe/clients/go/v8 v8.1.0
+require github.com/camunda/zeebe/clients/go/v8 v8.1.1
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -43,6 +43,8 @@ github.com/camunda/zeebe/clients/go/v8 v8.0.6 h1:6bIx/wdrjMlXs8+XZ2eJxru4XZwz9lM
 github.com/camunda/zeebe/clients/go/v8 v8.0.6/go.mod h1:vqeNO1EphExqC15spP56PNXQ6SB8sMjhEfO16bfFRPo=
 github.com/camunda/zeebe/clients/go/v8 v8.1.0 h1:/xrKg1T0KNdca9al3clnG51DkP/KEzGvEOC/Zp2i5+w=
 github.com/camunda/zeebe/clients/go/v8 v8.1.0/go.mod h1:HZ7hlFKAfCkdLeLds0nqEO48FDRl8LCBaAtDu9GxaAI=
+github.com/camunda/zeebe/clients/go/v8 v8.1.1 h1:RMtb8NlSf9hFNudNTUEjr3jcC/XYRwtNA/nXhQb41FU=
+github.com/camunda/zeebe/clients/go/v8 v8.1.1/go.mod h1:HZ7hlFKAfCkdLeLds0nqEO48FDRl8LCBaAtDu9GxaAI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <zeebe.version>8.1.0</zeebe.version>
+    <zeebe.version>8.1.1</zeebe.version>
     <log4j.version>2.19.0</log4j.version>
     <main.class>io.camunda.getstarted.DeployAndStartInstance</main.class>
   </properties>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -19,7 +19,7 @@
 	<properties>
 		<java.version>11</java.version>
 		<spring-zeebe.version>8.1.0</spring-zeebe.version>
-		<zeebe.version>8.1.0</zeebe.version>
+		<zeebe.version>8.1.1</zeebe.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Update of zeebe versions to `8.1.1`, based on [human task](https://bru-3.tasklist.ultrawombat.com/b051f158-2779-479f-84dc-1f16c8f808df/2251799817936585).