### PR TITLE
deps(go): bump zeebe to 8.1.2

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -2,7 +2,7 @@ module github.com/camunda/camunda-platform-get-started/go
 
 go 1.17
 
-require github.com/camunda/zeebe/clients/go/v8 v8.1.1
+require github.com/camunda/zeebe/clients/go/v8 v8.1.2
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -45,6 +45,8 @@ github.com/camunda/zeebe/clients/go/v8 v8.1.0 h1:/xrKg1T0KNdca9al3clnG51DkP/KEzG
 github.com/camunda/zeebe/clients/go/v8 v8.1.0/go.mod h1:HZ7hlFKAfCkdLeLds0nqEO48FDRl8LCBaAtDu9GxaAI=
 github.com/camunda/zeebe/clients/go/v8 v8.1.1 h1:RMtb8NlSf9hFNudNTUEjr3jcC/XYRwtNA/nXhQb41FU=
 github.com/camunda/zeebe/clients/go/v8 v8.1.1/go.mod h1:HZ7hlFKAfCkdLeLds0nqEO48FDRl8LCBaAtDu9GxaAI=
+github.com/camunda/zeebe/clients/go/v8 v8.1.2 h1:qQhsgGoJIUEncTQYmu+uAtueYFCzfVKFd5YHij0oCsw=
+github.com/camunda/zeebe/clients/go/v8 v8.1.2/go.mod h1:HZ7hlFKAfCkdLeLds0nqEO48FDRl8LCBaAtDu9GxaAI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=


### PR DESCRIPTION
Part of Zeebe release 8.1.2

- [Human task](https://bru-3.tasklist.ultrawombat.com/b051f158-2779-479f-84dc-1f16c8f808df/2251799818095012)

Java and Spring versions are taken care of by Dependabot
- #154 
- #155 