### PR TITLE
deps(go): bump zeebe to 8.1.3

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -2,7 +2,7 @@ module github.com/camunda/camunda-platform-get-started/go
 
 go 1.17
 
-require github.com/camunda/zeebe/clients/go/v8 v8.1.2
+require github.com/camunda/zeebe/clients/go/v8 v8.1.3
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -47,6 +47,8 @@ github.com/camunda/zeebe/clients/go/v8 v8.1.1 h1:RMtb8NlSf9hFNudNTUEjr3jcC/XYRwt
 github.com/camunda/zeebe/clients/go/v8 v8.1.1/go.mod h1:HZ7hlFKAfCkdLeLds0nqEO48FDRl8LCBaAtDu9GxaAI=
 github.com/camunda/zeebe/clients/go/v8 v8.1.2 h1:qQhsgGoJIUEncTQYmu+uAtueYFCzfVKFd5YHij0oCsw=
 github.com/camunda/zeebe/clients/go/v8 v8.1.2/go.mod h1:HZ7hlFKAfCkdLeLds0nqEO48FDRl8LCBaAtDu9GxaAI=
+github.com/camunda/zeebe/clients/go/v8 v8.1.3 h1:fuJD2DGByGCpfbrggWnz2onUr7ATNgkC4aOHBs7QxMw=
+github.com/camunda/zeebe/clients/go/v8 v8.1.3/go.mod h1:HZ7hlFKAfCkdLeLds0nqEO48FDRl8LCBaAtDu9GxaAI=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=


### PR DESCRIPTION
Part of Zeebe release 8.1.3

- [Human task](https://bru-3.tasklist.ultrawombat.com/3953a05c-7c20-41fb-8231-ec283dd2138b/4503599628982475?filter=all-open)

Java and Spring versions are taken care of by Dependabot:

- #160 
- #161 