### PR TITLE
deps: bump zeebe to 8.5.5

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 toolchain go1.21.8
 
-require github.com/camunda/zeebe/clients/go/v8 v8.5.4
+require github.com/camunda/zeebe/clients/go/v8 v8.5.5
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,15 +1,7 @@
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
-github.com/camunda/zeebe/clients/go/v8 v8.5.0 h1:cEKkBNsu17dIYOG5NyF8HZOuNx6bmJSkqjr4YsbLkzM=
-github.com/camunda/zeebe/clients/go/v8 v8.5.0/go.mod h1:UO1POEqpIUY04pidoY3lVD3UXXFqLn+dsYIaCuwymYk=
-github.com/camunda/zeebe/clients/go/v8 v8.5.1 h1:pqQYBFU/qjgwMsL2Dj1WkOez9JBDAKycFK/xrr3gAjk=
-github.com/camunda/zeebe/clients/go/v8 v8.5.1/go.mod h1:mx6wq3Z6Mfjda3yDe6Pl1G6BjX+VjkYYtWgoRQPgoFQ=
-github.com/camunda/zeebe/clients/go/v8 v8.5.2 h1:08OOgFzJnQoWAVONhD07U3em3wkWTXB/oFtzvKnHneE=
-github.com/camunda/zeebe/clients/go/v8 v8.5.2/go.mod h1:mx6wq3Z6Mfjda3yDe6Pl1G6BjX+VjkYYtWgoRQPgoFQ=
-github.com/camunda/zeebe/clients/go/v8 v8.5.3 h1:froVKeE0Mdgu8gii4BuRU1cZ+BzvMbDlo6qzQVghhZ4=
-github.com/camunda/zeebe/clients/go/v8 v8.5.3/go.mod h1:mx6wq3Z6Mfjda3yDe6Pl1G6BjX+VjkYYtWgoRQPgoFQ=
-github.com/camunda/zeebe/clients/go/v8 v8.5.4 h1:Ebhe2ltRhDBsh6RmfztMxtKI/vFFh7BVFV7bnJoWaY0=
-github.com/camunda/zeebe/clients/go/v8 v8.5.4/go.mod h1:RU4M+PQPYDa6KyyjdWBhgBlml2QGc9LIi9N2JBi6jBc=
+github.com/camunda/zeebe/clients/go/v8 v8.5.5 h1:oH76KKA5+CZi6S5U9r56piR9SjnMDOfIscx7FbZwe4A=
+github.com/camunda/zeebe/clients/go/v8 v8.5.5/go.mod h1:RU4M+PQPYDa6KyyjdWBhgBlml2QGc9LIi9N2JBi6jBc=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -51,8 +43,6 @@ golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.22.0 h1:9sGLhx7iRIHEiX0oAJ3MRZMUCElJgy7Br1nO+AMN3Tc=
-golang.org/x/net v0.22.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
 golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/oauth2 v0.18.0 h1:09qnuIAgzdx1XplqJvW6CQqMCtGZykZWcXzPMPUusvI=

--- a/java/README.md
+++ b/java/README.md
@@ -13,7 +13,7 @@ provides a Zeebe client.
 <dependency>
 	<groupId>io.camunda</groupId>
 	<artifactId>zeebe-client-java</artifactId>
-	<version>8.5.4</version>
+	<version>8.5.5</version>
 </dependency>
 ```
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <zeebe.version>8.5.4</zeebe.version>
+    <zeebe.version>8.5.5</zeebe.version>
     <log4j.version>2.19.0</log4j.version>
     <main.class>io.camunda.getstarted.DeployAndStartInstance</main.class>
   </properties>

--- a/spring/README.md
+++ b/spring/README.md
@@ -12,7 +12,7 @@ provides a Zeebe client.
 <dependency>
   <groupId>io.camunda</groupId>
   <artifactId>spring-zeebe-starter</artifactId>
-  <version>8.5.4</version>
+  <version>8.5.5</version>
 </dependency>
 ```
 

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -19,7 +19,7 @@
 	<properties>
 		<java.version>11</java.version>
 		<spring-zeebe.version>8.1.17</spring-zeebe.version>
-		<zeebe.version>8.5.4</zeebe.version>
+		<zeebe.version>8.5.5</zeebe.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
**Description**

This PR bumps the Zeebe dependencies to 8.5.5.