### PR TITLE
Bump Zeebe to 8.6.0

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -13,7 +13,7 @@ provides a Zeebe client.
 <dependency>
 	<groupId>io.camunda</groupId>
 	<artifactId>zeebe-client-java</artifactId>
-	<version>8.5.6</version>
+	<version>8.6.0</version>
 </dependency>
 ```
 

--- a/java/README.md
+++ b/java/README.md
@@ -13,7 +13,7 @@ provides a Zeebe client.
 <dependency>
 	<groupId>io.camunda</groupId>
 	<artifactId>zeebe-client-java</artifactId>
-	<version>8.6.0</version>
+	<version>8.6.1</version>
 </dependency>
 ```
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <zeebe.version>8.5.6</zeebe.version>
+    <zeebe.version>8.6.0</zeebe.version>
     <log4j.version>2.19.0</log4j.version>
     <main.class>io.camunda.getstarted.DeployAndStartInstance</main.class>
   </properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <zeebe.version>8.6.0</zeebe.version>
+    <zeebe.version>8.6.1</zeebe.version>
     <log4j.version>2.19.0</log4j.version>
     <main.class>io.camunda.getstarted.DeployAndStartInstance</main.class>
   </properties>


### PR DESCRIPTION
## Description
* Bumps the version in the Java guide
* Does not adjust any other guide
  * Go client has moved to the community - needs clarification from @megglos what to do with this in the future.
  * Spring has a [newer dedicated guide](https://github.com/camunda/camunda-8-get-started-spring) - will be clarified in https://github.com/camunda/developer-experience/issues/406
