### PR TITLE
deps: bump zeebe to version 8.6.12

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -13,7 +13,7 @@ provides a Zeebe client.
 <dependency>
 	<groupId>io.camunda</groupId>
 	<artifactId>zeebe-client-java</artifactId>
-	<version>8.6.11</version>
+	<version>8.6.12</version>
 </dependency>
 ```
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <zeebe.version>8.6.11</zeebe.version>
+    <zeebe.version>8.6.12</zeebe.version>
     <log4j.version>2.19.0</log4j.version>
     <main.class>io.camunda.getstarted.DeployAndStartInstance</main.class>
   </properties>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -12,7 +12,7 @@
 	<properties>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
-		<zeebe.version>8.6.11</zeebe.version>
+		<zeebe.version>8.6.12</zeebe.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Update the (Java) Getting Started guides to Zeebe version `8.6.12`.