### PR TITLE
Bump zeebe to `8.7.0`

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -13,7 +13,7 @@ provides a Zeebe client.
 <dependency>
 	<groupId>io.camunda</groupId>
 	<artifactId>zeebe-client-java</artifactId>
-	<version>8.6.12</version>
+	<version>8.7.0</version>
 </dependency>
 ```
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <zeebe.version>8.6.12</zeebe.version>
+    <zeebe.version>8.7.0</zeebe.version>
     <log4j.version>2.19.0</log4j.version>
     <main.class>io.camunda.getstarted.DeployAndStartInstance</main.class>
   </properties>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -12,7 +12,7 @@
 	<properties>
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
-		<zeebe.version>8.6.12</zeebe.version>
+		<zeebe.version>8.7.0</zeebe.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Part of [this task](https://bru-2.tasklist.camunda.io/689a796f-7efa-487f-9e44-76ca3a98c77b/tasklist/4503599749872668) in the release process.

- Updates the zeebe version in the java project to 8.7.0
- Updates the zeebe version in the spring project to 8.7.0

Does not update the go version, as [no 8.7.0 version for it was released by us](https://github.com/camunda/camunda/blob/8.7.0/clients/go/README.md).